### PR TITLE
Fix bad update message

### DIFF
--- a/src/bot/a2exams_bot.py
+++ b/src/bot/a2exams_bot.py
@@ -67,7 +67,7 @@ def check(update: Update, context: CallbackContext) -> None:
     if error_cities:
         error_msg = f'No exams in {",".join(error_cities)}\n'
     schools = a2exams_checker.get_schools_from_file(cities_filter=requested_cities)
-    msg = a2exams_checker.diff_to_str(schools)
+    msg = a2exams_checker.diff_to_str(schools, url_in_header=True)
     update.effective_message.reply_text(f'{error_msg}{msg}')
 
 
@@ -110,7 +110,7 @@ def _do_inform(context, chat_ids, new_state, prev_state):
     """Asynchronous status update for subscribers is done here"""
     for chat_id in chat_ids:
         chosen_cities = _get_tracked_cities(chat_id)
-        message = a2exams_checker.diff_to_str(new_state, prev_state, chosen_cities)
+        message = a2exams_checker.diff_to_str(new_state, prev_state, chosen_cities, url_in_header=True)
         context.bot.send_message(chat_id=chat_id, text=message or "No change")
 
 

--- a/src/bot/a2exams_bot.py
+++ b/src/bot/a2exams_bot.py
@@ -1,5 +1,6 @@
 """A telegram bot to check and track A2 exams registration"""
 
+import copy
 import html
 import json
 import logging
@@ -118,7 +119,10 @@ def inform_about_change(context: CallbackContext) -> None:
     global SCHOOLS_DATA
     new_data = a2exams_checker.get_schools_from_file()
     if not SCHOOLS_DATA or a2exams_checker.has_changes(new_data, SCHOOLS_DATA):
-        context.dispatcher.run_async(_do_inform, context, _get_all_subscribers(), new_data, SCHOOLS_DATA)
+        # Now deep copy new_data and old_data for every subscriber to get the same update
+        new_state = copy.deepcopy(new_data)
+        prev_state = copy.deepcopy(SCHOOLS_DATA)
+        context.dispatcher.run_async(_do_inform, context, _get_all_subscribers(), new_state, prev_state)
         SCHOOLS_DATA = new_data
 
 

--- a/src/checker/a2exams_checker.py
+++ b/src/checker/a2exams_checker.py
@@ -104,7 +104,7 @@ async def fetch_schools(url=URL, filename=LAST_FETCHED, tag='div', cls='town'):
     return _html_to_list(html, tag=tag, cls=cls)
 
 
-def diff_to_str(new_data, old_data=None, cities=None):
+def diff_to_str(new_data, old_data=None, cities=None, url_in_header=False):
     """
     Return a human readable state of exams registration in chosen cities (no cities chosen means all cities).
     If previous state is passed then only changes to the state will be accounted for.
@@ -133,6 +133,9 @@ def diff_to_str(new_data, old_data=None, cities=None):
     if msg:
         # Add date from last city processed
         msg = f'Update from {date}:\n{msg}'
+        # If requested - add url
+        if url_in_header:
+            msg = f'{URL}\n{msg}'
     return msg
 
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -80,6 +80,9 @@ def test_diff_to_str_no_prev_state():
     msg = a2exams_checker.diff_to_str(new_data, cities=['Brno', 'Praha', 'Tabor', 'nosuchcity'])
     expected = 'Brno :(\nPraha :(\nTábor :('
     _assert_matches(msg, expected)
+    # Make sure URL is shown when requested
+    msg = a2exams_checker.diff_to_str(new_data, url_in_header=True)
+    assert msg.startswith(a2exams_checker.URL)
 
 
 def test_diff_to_str_prev_state():


### PR DESCRIPTION
The problem appeared because of bad usage of
_get_tracked_cities_str, which would return either a
comma-separated list of cities OR an 'all cities' string
and was intended to be used for human-readable messages
generation only. The attempt to get a list of cities from
this representation to be used in filtering resulted in
empty update and thus the 'No change' message.
This was mitigated by introducing a _get_tracked_cities
and using it for filtering purposes.

Closes: #4