### PR TITLE
 Add possibility to track exams in cities with 2 words in name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ This will run 3 containers - the fetcher, redis and telegram bot. To properly se
 your own `.env` file from the given `.env.sample`.
 
 Available bot commands:
-- /cities - List cities where exam takes place. Can be used as arguments to /track command
+- /cities - List cities where exam takes place. Can be used as arguments to /track command (separator - comma)
 - /track - Subscribe to updates
 - /notrack - Unsubscribe
 - /users - Show how many users are subscribed for updates
 - /mystatus - Check if you are tracking status updates at the moment
 - /check - Check status in all cities right now
 
-Once the user subscribes to the updates using `/track` or `/track praha brno kolin`, the bot will inform them about
+Once the user subscribes to the updates using `/track` or `/track praha, brno, kolin`, the bot will inform them about
 any status change as soon as it happens.
 
 ## To be done

--- a/src/bot/a2exams_bot.py
+++ b/src/bot/a2exams_bot.py
@@ -31,7 +31,7 @@ logger.setLevel(logging.DEBUG)
 
 def _vet_requested_cities(user_requested_cities, source_of_truth=SCHOOLS_DATA):
     """Returns a tuple (cities_ok, cities_error) """
-    requested_cities = [" ".join(map(lambda d: d.capitalize(), unidecode.unidecode(c).lower().split(' ')))
+    requested_cities = [" ".join(map(lambda d: d.title(), unidecode.unidecode(c).lower().split(' ')))
                         for c in user_requested_cities]
     if requested_cities:
         invalid_options = set(requested_cities) - set(source_of_truth.keys())

--- a/src/bot/a2exams_bot.py
+++ b/src/bot/a2exams_bot.py
@@ -31,7 +31,7 @@ logger.setLevel(logging.DEBUG)
 
 def _vet_requested_cities(user_requested_cities, source_of_truth=SCHOOLS_DATA):
     """Returns a tuple (cities_ok, cities_error) """
-    requested_cities = [unidecode.unidecode(c).lower().capitalize() for c in user_requested_cities]
+    requested_cities = [" ".join(map(lambda d: d.capitalize(), unidecode.unidecode(c).lower().split(' '))) for c in user_requested_cities]
     if requested_cities:
         invalid_options = set(requested_cities) - set(source_of_truth.keys())
         if invalid_options:
@@ -90,7 +90,7 @@ def _is_admin(chat_id):
 
 
 def check(update: Update, context: CallbackContext) -> None:
-    requested_cities, error_cities = _vet_requested_cities(context.args)
+    requested_cities, error_cities = _vet_requested_cities(" ".join(context.args).split(','))
     error_msg = ''
     if error_cities:
         error_msg = f'No exams in {",".join(error_cities)}\n'
@@ -107,7 +107,7 @@ def cities(update: Update, context: CallbackContext) -> None:
 
 def track(update: Update, context: CallbackContext) -> None:
     error_msg = ''
-    requested_cities, error_cities = _vet_requested_cities(context.args)
+    requested_cities, error_cities = _vet_requested_cities(" ".join(context.args).split(','))
     cities_str = ','.join(sorted(requested_cities))
     if error_cities:
         error_msg = f'No exams in {",".join(error_cities)}\n'

--- a/src/bot/a2exams_bot.py
+++ b/src/bot/a2exams_bot.py
@@ -31,7 +31,8 @@ logger.setLevel(logging.DEBUG)
 
 def _vet_requested_cities(user_requested_cities, source_of_truth=SCHOOLS_DATA):
     """Returns a tuple (cities_ok, cities_error) """
-    requested_cities = [" ".join(map(lambda d: d.capitalize(), unidecode.unidecode(c).lower().split(' '))) for c in user_requested_cities]
+    requested_cities = [" ".join(map(lambda d: d.capitalize(), unidecode.unidecode(c).lower().split(' ')))
+                        for c in user_requested_cities]
     if requested_cities:
         invalid_options = set(requested_cities) - set(source_of_truth.keys())
         if invalid_options:
@@ -89,8 +90,14 @@ def _is_admin(chat_id):
     return int(chat_id) == int(DEVELOPER_CHAT_ID)
 
 
+def _parse_cities_args(context_args):
+    # NOTE(ivasilev) Stripping whitespaces is necessary for correct parsing of 'Praha   , Brno , Ceske budejovice'
+    preprocessed_args = [city.strip() for city in " ".join(context_args).split(',') if city.strip()]
+    return _vet_requested_cities(preprocessed_args)
+
+
 def check(update: Update, context: CallbackContext) -> None:
-    requested_cities, error_cities = _vet_requested_cities(" ".join(context.args).split(','))
+    requested_cities, error_cities = _parse_cities_args(context.args)
     error_msg = ''
     if error_cities:
         error_msg = f'No exams in {",".join(error_cities)}\n'
@@ -107,7 +114,7 @@ def cities(update: Update, context: CallbackContext) -> None:
 
 def track(update: Update, context: CallbackContext) -> None:
     error_msg = ''
-    requested_cities, error_cities = _vet_requested_cities(" ".join(context.args).split(','))
+    requested_cities, error_cities = _parse_cities_args(context.args)
     cities_str = ','.join(sorted(requested_cities))
     if error_cities:
         error_msg = f'No exams in {",".join(error_cities)}\n'

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -7,6 +7,18 @@ import mock
 LAST_FETCHED = 'tests/data/last_fetched.html'
 
 
+def test__parse_cities_args():
+    schools_data = a2exams_checker.get_schools_from_file(LAST_FETCHED)
+    # The multi-whitespaces case
+    context_args = ['plzEn', ',', 'praha', ',', 'ceske', 'budejovice']
+    res, errors = a2exams_bot._parse_cities_args(context_args)
+    assert (res, errors) == (['Ceske Budejovice', 'Plzen', 'Praha'], [])
+    # Make sure that an empty list results in no errors
+    context_args = []
+    res, errors = a2exams_bot._parse_cities_args(context_args)
+    assert (res, errors) == ([], [])
+
+
 def test_vet_cities_args():
     schools_data = a2exams_checker.get_schools_from_file(LAST_FETCHED)
     # Request cities with diacrytics should work just like without one
@@ -22,6 +34,10 @@ def test_vet_cities_args():
     requested_cities = ['pRAHA', 'nosuchcity', 'cityof42']
     res, errors = a2exams_bot._vet_requested_cities(requested_cities)
     assert (res, errors) == (['Praha'], ['Cityof42', 'Nosuchcity'])
+    # If a properly parsed list of cities is passed then 2 words in name are fine
+    requested_cities = ['pRAHA', 'Ceske budejovice']
+    res, errors = a2exams_bot._vet_requested_cities(requested_cities)
+    assert (res, errors) == (['Ceske Budejovice', 'Praha'], [])
 
 
 def _mock_redis(values=None):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -38,6 +38,10 @@ def test_vet_cities_args():
     requested_cities = ['pRAHA', 'Ceske budejovice']
     res, errors = a2exams_bot._vet_requested_cities(requested_cities)
     assert (res, errors) == (['Ceske Budejovice', 'Praha'], [])
+    # Allow tracking in Frydek-Mistek as well (previously that was forcefully converted to Frydek-mistek)
+    requested_cities = ['frydek-mistek']
+    res, errors = a2exams_bot._vet_requested_cities(requested_cities)
+    assert (res, errors) == (['Frydek-Mistek'], [])
 
 
 def _mock_redis(values=None):


### PR DESCRIPTION
fixes #15

Usage:

```
/track Subscribe to status updates. All cities shown by default, track city1,city2,city3 subscribes to select city updates only.
```

example `/track ceske budejovice,pisek,plzen`:

```
You are tracking exam slots in Ceske Budejovice,Pisek,Plzen
```